### PR TITLE
fix webo-join to o_join

### DIFF
--- a/app/controllers/frontend/UserController.php
+++ b/app/controllers/frontend/UserController.php
@@ -292,7 +292,7 @@ class UserController extends BaseController
                                 }
                             }
                         } else {
-                            self::renderBase(['page_title' => '微博登录', 'active' => 'weibo-join']);
+                            self::renderBase(['page_title' => '微博登录', 'active' => 'o_join']);
 
                             Roc::render('o_join', [
                                 'avatar' => $avatar,


### PR DESCRIPTION
微博登录后，在完善资料页面样式不存在。
修改 App/controllers/frontend/UserController.php 文件第295行 ‘active’=>‘weibo-join’ 为 ‘active’=>‘o_join’ 后恢复正常。